### PR TITLE
fix for #28 where --info doesn't choose right arch

### DIFF
--- a/modules/argparser.py
+++ b/modules/argparser.py
@@ -4,6 +4,7 @@
 
 # Modules from standard library
 from __future__ import print_function
+from platform import machine
 from sys import exit, stderr
 try:
     import configargparse as argparse
@@ -141,8 +142,8 @@ def parse():
         '-l', '--list', action='store_true',
         help="List available templates")
     grpA.add_argument(
-        '--arch', choices=['x86_64', 'i386', 'i686', 'ia64', 'armv71', 'ppc', 'ppc64', 'ppc64le', 'aarch64', 'sparc64', 's390', 's390x'],
-        help="Specify architecture (defaults to same architecture you're running)")
+        '--arch', choices=['x86_64', 'i386', 'i686', 'ia64', 'armv71', 'ppc', 'ppc64', 'ppc64le', 'aarch64', 'sparc64', 's390', 's390x'], default=machine(),
+        help="Specify architecture in case there are multiple choices (defaults to same architecture as {})".format(cfg.prog))
     grpA.add_argument(
         '--info', dest='showMetadataOnly', action='store_true',
         help="Print virt-builder metadata for chosen template")

--- a/modules/cfg.py
+++ b/modules/cfg.py
@@ -13,7 +13,7 @@ import json
 from . import string_ops as c
 
 # Version info
-__version__ = '0.10.1'
+__version__ = '0.10.2'
 __date__    = '2016/02/09'
 
 # All references to program name should use this

--- a/modules/sysvalidator.py
+++ b/modules/sysvalidator.py
@@ -72,7 +72,7 @@ def check_if_requested_template_exists():
 def isolate_metadata_for_chosen_vb_template():
     """Save json for chosen virt-builder template."""
     for template in cfg.templateList:
-        if template['os-version'] == cfg.opts.templateName:
+        if template['os-version'] == cfg.opts.templateName and template['arch'] == cfg.opts.arch:
             cfg.templateInfo = template
 
 def if_metadata_requested_then_print_and_quit():


### PR DESCRIPTION
Simple fix but now with this we explicitly pass `--arch xxx` to `virt-builder`. (Where `xxx` is returned from python's `platform.machine()`.)
